### PR TITLE
commitment share proofs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,311 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'blockstore'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=blockstore"
+                ],
+                "filter": {
+                    "name": "blockstore",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'lumina-cli'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=lumina-cli"
+                ],
+                "filter": {
+                    "name": "lumina-cli",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'lumina'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=lumina",
+                    "--package=lumina-cli"
+                ],
+                "filter": {
+                    "name": "lumina",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'lumina'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=lumina",
+                    "--package=lumina-cli"
+                ],
+                "filter": {
+                    "name": "lumina",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'celestia-rpc'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=celestia-rpc"
+                ],
+                "filter": {
+                    "name": "celestia-rpc",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'p2p'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=p2p",
+                    "--package=celestia-rpc"
+                ],
+                "filter": {
+                    "name": "p2p",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'header'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=header",
+                    "--package=celestia-rpc"
+                ],
+                "filter": {
+                    "name": "header",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'blob'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=blob",
+                    "--package=celestia-rpc"
+                ],
+                "filter": {
+                    "name": "blob",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'state'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=state",
+                    "--package=celestia-rpc"
+                ],
+                "filter": {
+                    "name": "state",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'share'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=share",
+                    "--package=celestia-rpc"
+                ],
+                "filter": {
+                    "name": "share",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'celestia-types'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=celestia-types"
+                ],
+                "filter": {
+                    "name": "celestia-types",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'celestia-proto'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=celestia-proto"
+                ],
+                "filter": {
+                    "name": "celestia-proto",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'lumina-node'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=lumina-node"
+                ],
+                "filter": {
+                    "name": "lumina-node",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'header_ex'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=header_ex",
+                    "--package=lumina-node"
+                ],
+                "filter": {
+                    "name": "header_ex",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'node'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=node",
+                    "--package=lumina-node"
+                ],
+                "filter": {
+                    "name": "node",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'lumina-node-wasm'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=lumina-node-wasm"
+                ],
+                "filter": {
+                    "name": "lumina-node-wasm",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
Get a merkle path from a share, to the blob commitment (merkle mountain range of NMT subtree roots, [ADR013](https://github.com/celestiaorg/celestia-app/blob/main/docs/architecture/adr-013-non-interactive-default-rules-for-zero-padding.md))